### PR TITLE
Fix Acorn 4.x support

### DIFF
--- a/src/Providers/ExampleServiceProvider.php
+++ b/src/Providers/ExampleServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace VendorName\ExamplePackage\Providers;
 
-use Roots\Acorn\ServiceProvider;
+use Illuminate\Support\ServiceProvider;
 use VendorName\ExamplePackage\Console\ExampleCommand;
 use VendorName\ExamplePackage\Example;
 


### PR DESCRIPTION
In https://github.com/roots/acorn/commit/f5394b0e800c16683c519f8f3bbeef5f74aef425 (4.x) the `Roots\Acorn\ServiceProvider::class` is changed to `final` instead of `abstract`. Thus we cannot extend this class in an Acorn package anymore and we need to extend `Illuminate\Support\ServiceProvider` instead.